### PR TITLE
feat: Add app engine application in europe-west

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+resource "google_app_engine_application" "app" {
+  project     = var.project_id
+  location_id = var.region
+}
 
 resource "google_cloud_scheduler_job" "job" {
   count = var.create_job ? length(var.scheduled_jobs) : 0

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable project_id {
  variable region {
    type    = string
    description = "Region where the scheduler job resides. If it is not provided, Terraform will use the provider default"
-   default = "europe-west1"
+   default     = "europe-west"
  }
 
 variable scheduled_jobs {


### PR DESCRIPTION
`To use Cloud Scheduler your project must contain an App Engine app that is located in one of the supported regions. If your project does not have an App Engine app, you must create one.`