### PR TITLE
fix: split regions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ scheduled_jobs = [
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:-----:|
+| app_engine_region | Region to serve the app from | `string` | `europe-west` | no |
 | create\_job | Specify true if you want to create a job | `bool` | `true` | no |
 | project\_id | Project ID where the jobs will be created | `string` | n/a | yes |
 | region | Region where the scheduler job resides. If it is not provided, Terraform will use the provider default | `string` | `europe-west1` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 resource "google_app_engine_application" "app" {
   project     = var.project_id
-  location_id = var.region
+  location_id = var.app_engine_region
 }
 
 resource "google_cloud_scheduler_job" "job" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,11 +12,18 @@ variable project_id {
  variable region {
    type    = string
    description = "Region where the scheduler job resides. If it is not provided, Terraform will use the provider default"
-   default     = "europe-west"
+   default     = "europe-west1"
  }
 
 variable scheduled_jobs {
   type        = list(map(string))
   description = "The list of the jobs to be created"
   default     = []
+}
+
+
+variable app_engine_region {
+   type        = string
+   description = "Region to serve the app from"
+   default     = "europe-west"
 }


### PR DESCRIPTION
Two locations, called `europe-west` and `us-central` in App Engine commands, are called, respectively, `europe-west1` and `us-central1` in Cloud Scheduler commands.